### PR TITLE
Support for POST request to view, adding "keys" to the body.

### DIFF
--- a/Source/TDView.h
+++ b/Source/TDView.h
@@ -39,6 +39,7 @@ typedef struct TDQueryOptions {
     BOOL inclusiveEnd;
     BOOL reduce;
     BOOL group;
+    __unsafe_unretained id keys;
 } TDQueryOptions;
 
 extern const TDQueryOptions kDefaultTDQueryOptions;

--- a/Source/TDView.m
+++ b/Source/TDView.m
@@ -277,6 +277,24 @@ static id fromJSON( NSData* json ) {
     [sql appendString: @" FROM maps, revs, docs WHERE maps.view_id=?"];
     NSMutableArray* args = $marray($object(_viewID));
 
+    id keys = options->keys;
+    
+    if ([keys isKindOfClass:[NSArray class]]) {
+        
+        [sql appendString:@" AND ("];
+        
+        for (NSString * key in (NSArray *)keys) {
+            
+            [sql appendString:@"key = ?"];
+            [args addObject: toJSONString(key)];
+            
+            if (key != [keys lastObject])
+                [sql appendString:@" OR "];
+        }
+        
+        [sql appendString:@")"];
+    }
+    
     id minKey = options->startKey, maxKey = options->endKey;
     BOOL inclusiveMin = YES, inclusiveMax = options->inclusiveEnd;
     if (options->descending) {


### PR DESCRIPTION
Added support for issuing a POST request to a view and adding the structure {"keys": ["key1", "key2", ...]} to the body, as per http://wiki.apache.org/couchdb/HTTP_view_API
