### PR TITLE
HTTP listener returns 400 Bad Request for PUT /newdbname

### DIFF
--- a/Listener/TDHTTPConnection.m
+++ b/Listener/TDHTTPConnection.m
@@ -79,8 +79,16 @@
 
 
 - (BOOL)expectsRequestBodyFromMethod:(NSString *)method atPath:(NSString *)path {
-	return $equal(method, @"POST") || $equal(method, @"PUT")
-		|| [super expectsRequestBodyFromMethod:method atPath:path];
+    BOOL putWithBody = NO;
+    if ($equal(method, @"PUT")) {
+        // Allow PUT to /newdbname without a request body as per
+        // http://wiki.apache.org/couchdb/HTTP_database_API#PUT_.28Create_New_Database.29
+        // superclass implementation returns YES
+        // NOTE: initial empty string:  "/newdbname" -> ("", "newdbname")
+        NSArray * comp = [path componentsSeparatedByString:@"/"];
+        return [comp count] != 2; 
+    }
+    $equal(method, @"POST") || [super expectsRequestBodyFromMethod:method atPath:path];
 }
 
 - (void)prepareForBodyWithSize:(UInt64)contentLength {


### PR DESCRIPTION
Default behavior in TDHTTPConnection expectsRequestBodyFromMethod:atPath: is to return YES for all PUT requests, which prevents clients from creating a database using HTTP as per the [CouchDB HTTP API](http://wiki.apache.org/couchdb/HTTP_database_API#PUT_.28Create_New_Database.29).  Fix is to allow a PUT request if there is only one component on the URL.
