### PR TITLE
TouchDB-iOS Exception

### DIFF
--- a/Source/ChangeTracker/TDSocketChangeTracker.m
+++ b/Source/ChangeTracker/TDSocketChangeTracker.m
@@ -254,7 +254,9 @@ enum {
             } else {
                 uint8_t buffer[8192];
                 bytesRead = [stream read: buffer maxLength: sizeof(buffer)];
-                [_inputBuffer appendBytes: buffer length: bytesRead];
+                if (bytesRead > 0) {
+                    [_inputBuffer appendBytes: buffer length: bytesRead];
+                }
             }
             LogTo(ChangeTracker, @"%@: read %ld bytes", self, (long)bytesRead);
             [self readLines];


### PR DESCRIPTION
Summary:  I found a situation in which bytes_read is -1 on line 259 of TDSocketChangeTracker.m and is causing an uncaught exception.  I added protection to avoid attempting to append bytes when bytes_read is -1.

TL;DR Version

Last night I downloaded the lastest TouchDB-iOS and corresponding CouchCocoa (branch:touchdb) and used them in my prototype app.  After some modifications on my end, everything was looking and working great.  I came in this morning, turned on the device I use for testing and the app immediately crashed.  I tried the same experiment with the Demo-iOS target and experienced the same crash.

Here are the steps I used to replicate the problem:
1.  Uninstall the Demo-iOS app from the device.
2.  Run the Demo-iOS app from the TouchDB-iOS project and configure it to point to an CouchDB 1.1.1 server for syncing.  I'm using IrisCouch.
3.  Wait for the sync to finish
4.  Briefly press the power button to lock the device
5.  Wait 5 seconds
6.  Swipe to unlock the device
7.  Crash:

<pre>
2012-03-28 09:36:56.089 TouchDB Demo[756:3107] *** Terminating app due to uncaught exception 'NSMallocException', reason: '*** -[NSConcreteMutableData appendBytes:length:]: unable to allocate memory for length (4294967295)'
*** First throw call stack:
(0x30fe288f 0x3104a259 0x30fe2789 0x30fe27ab 0x307c0a49 0x307c073f 0x10deeb 0x30fb2433 0x30f77533 0x30f774e1 0x30f77353 0x376c6121 0x37652bb9 0x37652b39 0x30fb92ef 0x30fb6ad3 0x30fb629f 0x30fb5045 0x30f384a5 0x30f3836d 0x307a8b75 0x307c2523 0xfd751 0x307b4a81 0x30848591 0x378d8735 0x378d85f0)
terminate called throwing an exception
(lldb) image lookup -a 0x30fe288f
      Address: CoreFoundation[0x000b988f] (CoreFoundation.__TEXT.__text + 755647)
      Summary: CoreFoundation`__exceptionPreprocess + 163
(lldb) image lookup -a 0x3104a259
      Address: libobjc.A.dylib[0x00009259] (libobjc.A.dylib.__TEXT.__text + 33369)
      Summary: libobjc.A.dylib`objc_exception_throw + 33
(lldb) image lookup -a 0x30fe2789
      Address: CoreFoundation[0x000b9789] (CoreFoundation.__TEXT.__text + 755385)
      Summary: CoreFoundation`+[NSException raise:format:] + 1
(lldb) image lookup -a 0x30fe27ab
      Address: CoreFoundation[0x000b97ab] (CoreFoundation.__TEXT.__text + 755419)
      Summary: CoreFoundation`+[NSException raise:format:] + 35
(lldb) image lookup -a 0x307c0a49
      Address: Foundation[0x0001ca49] (Foundation.__TEXT.__text + 111221)
      Summary: Foundation`_NSMutableDataGrowBytes + 649
(lldb) image lookup -a 0x307c073f
      Address: Foundation[0x0001c73f] (Foundation.__TEXT.__text + 110443)
      Summary: Foundation`-[NSConcreteMutableData appendBytes:length:] + 291
(lldb) image lookup -v -a 0x10deeb
      Address: TouchDB Demo[0x0003aeeb] (TouchDB Demo.__TEXT.__text + 233167)
      Summary: TouchDB Demo`-[TDSocketChangeTracker stream:handleEvent:] + 651 at TDSocketChangeTracker.m:259
</pre>


Debugging further I found that in this situation that bytes_read is -1 on line 259 of TDSocketChangeTracker.m and this is causing the crash.  I put in a simple check for that situation to protect against the crash and all is well.
