### PR TITLE
Include prior current/undeleted documents in conflicts

### DIFF
--- a/Source/TDView.m
+++ b/Source/TDView.m
@@ -252,19 +252,18 @@ static id fromJSON( NSData* json ) {
                                                                   sequence: sequence
                                                                    options: 0];
                 if (properties) {
-                    // Find conflicts with documents from previous indexings.
-                    FMResultSet* r2 = nil;
-                    r2 = [fmdb executeQuery: @"SELECT revid FROM revs, docs "
-                          "WHERE sequence<=? AND docid=? AND current!=0 AND deleted=0 "
-                          "AND revs.doc_id = docs.doc_id "
-                          "ORDER BY revid DESC",
-                          $object(lastSequence), docID];
-                    while ([r2 next]) {
-                        if (!conflicts)
-                            conflicts = $marray();
-                        [conflicts addObject:[r2 stringForColumnIndex:0]];
+                    if (lastSequence > 0) {
+                        // Find conflicts with documents from previous indexings.
+                        FMResultSet* r2 = [fmdb executeQuery: @"SELECT revid FROM revs "
+                                                               "WHERE doc_id=? AND sequence<=? AND current!=0 AND deleted=0",
+                                                               $object(doc_id), $object(lastSequence)];
+                        while ([r2 next]) {
+                            if (!conflicts)
+                                conflicts = $marray();
+                            [conflicts addObject:[r2 stringForColumnIndex:0]];
+                        }
+                        [r2 close];
                     }
-                    [r2 close];
                     
                     if (conflicts) {
                         // Add a "_conflicts" property if there were conflicting revisions:

--- a/Source/TDView.m
+++ b/Source/TDView.m
@@ -252,6 +252,20 @@ static id fromJSON( NSData* json ) {
                                                                   sequence: sequence
                                                                    options: 0];
                 if (properties) {
+                    // Find conflicts with documents from previous indexings.
+                    FMResultSet* r2 = nil;
+                    r2 = [fmdb executeQuery: @"SELECT revid FROM revs, docs "
+                          "WHERE sequence<=? AND docid=? AND current!=0 AND deleted=0 "
+                          "AND revs.doc_id = docs.doc_id "
+                          "ORDER BY revid DESC",
+                          $object(lastSequence), docID];
+                    while ([r2 next]) {
+                        if (!conflicts)
+                            conflicts = $marray();
+                        [conflicts addObject:[r2 stringForColumnIndex:0]];
+                    }
+                    [r2 close];
+                    
                     if (conflicts) {
                         // Add a "_conflicts" property if there were conflicting revisions:
                         NSMutableDictionary* mutableProps = [[properties mutableCopy] autorelease];


### PR DESCRIPTION
I had designed a view to keep track of conflicts using the recently added`_conflicts` property.  I found that some conflicts weren't being passed to my view's map function.  Looking at the TDView.m (lines 218-223) it appears that only conflicts included in the current re-indexing (sequence>lastSequence) were noted as conflicts and passed in the `_conflicts` property.  I added code to find and include conflicts that were included in previous indexing attempts. 
