### PR TITLE
Change to be able to pass custom request headers on all requests.

### DIFF
--- a/Source/ChangeTracker/TDChangeTracker.h
+++ b/Source/ChangeTracker/TDChangeTracker.h
@@ -60,6 +60,7 @@ typedef enum TDChangeTrackerMode {
 @property (readonly, copy, nonatomic) id lastSequenceID;
 @property (retain, nonatomic) NSError* error;
 @property (assign, nonatomic) id<TDChangeTrackerClient> client;
+@property (retain, nonatomic) NSDictionary *requestHeaders;
 
 @property (copy) NSString* filterName;
 @property (copy) NSDictionary* filterParameters;

--- a/Source/ChangeTracker/TDChangeTracker.m
+++ b/Source/ChangeTracker/TDChangeTracker.m
@@ -35,6 +35,7 @@
 @synthesize lastSequenceID=_lastSequenceID, databaseURL=_databaseURL, mode=_mode;
 @synthesize heartbeat=_heartbeat, error=_error;
 @synthesize client=_client, filterName=_filterName, filterParameters=_filterParameters;
+@synthesize requestHeaders = _requestHeaders;
 
 - (id)initWithDatabaseURL: (NSURL*)databaseURL
                      mode: (TDChangeTrackerMode)mode
@@ -113,6 +114,7 @@
     [_databaseURL release];
     [_lastSequenceID release];
     [_error release];
+    [_requestHeaders release];
     [super dealloc];
 }
 

--- a/Source/ChangeTracker/TDConnectionChangeTracker.m
+++ b/Source/ChangeTracker/TDConnectionChangeTracker.m
@@ -34,6 +34,14 @@
     request.cachePolicy = NSURLRequestReloadIgnoringCacheData;
     request.timeoutInterval = 6.02e23;
     
+    // Add headers.
+    if ([_client respondsToSelector:@selector(authorizationHeader)]) {
+        [request addValue:[_client authorizationHeader] forHTTPHeaderField:@"Authorization"];
+    }
+    [self.requestHeaders enumerateKeysAndObjectsUsingBlock:^(id key, id value, BOOL *stop) {
+        [request addValue:value forHTTPHeaderField:key];
+    }];
+    
     _connection = [[NSURLConnection connectionWithRequest: request delegate: self] retain];
     LogTo(ChangeTracker, @"%@: Started... <%@>", self, request.URL);
     return YES;

--- a/Source/ChangeTracker/TDSocketChangeTracker.m
+++ b/Source/ChangeTracker/TDSocketChangeTracker.m
@@ -49,6 +49,15 @@ enum {
                                                           kCFHTTPVersion1_1);
     Assert(request);
     CFHTTPMessageSetHeaderFieldValue(request, CFSTR("Host"), (CFStringRef)_databaseURL.host);
+    
+    // Add headers.
+    if ([_client respondsToSelector:@selector(authorizationHeader)]) {
+        CFHTTPMessageSetHeaderFieldValue(request, CFSTR("Authorization"), (CFStringRef)[_client authorizationHeader]);
+    }
+    [self.requestHeaders enumerateKeysAndObjectsUsingBlock:^(id key, id value, BOOL *stop) {
+        CFHTTPMessageSetHeaderFieldValue(request, (CFStringRef)key, (CFStringRef)value);
+    }];
+    
     if (_unauthResponse && _credential) {
         CFIndex unauthStatus = CFHTTPMessageGetResponseStatusCode(_unauthResponse);
         Assert(CFHTTPMessageAddAuthentication(request, _unauthResponse,

--- a/Source/TDMultipartDownloader.h
+++ b/Source/TDMultipartDownloader.h
@@ -21,6 +21,7 @@
 - (id) initWithURL: (NSURL*)url
           database: (TDDatabase*)database
         authorizer: (id<TDAuthorizer>)authorizer
+    requestHeaders: (NSDictionary *) requestHeaders
       onCompletion: (TDRemoteRequestCompletionBlock)onCompletion;
 
 @property (readonly) NSDictionary* document;

--- a/Source/TDMultipartDownloader.m
+++ b/Source/TDMultipartDownloader.m
@@ -27,10 +27,14 @@
 - (id) initWithURL: (NSURL*)url
           database: (TDDatabase*)database
         authorizer: (id<TDAuthorizer>)authorizer
+    requestHeaders: (NSDictionary *) requestHeaders
       onCompletion: (TDRemoteRequestCompletionBlock)onCompletion
 {
-    self = [super initWithMethod: @"GET" URL: url body: nil
+    self = [super initWithMethod: @"GET" 
+                             URL: url 
+                            body: nil
                       authorizer: authorizer
+                  requestHeaders: requestHeaders
                     onCompletion: onCompletion];
     if (self) {
         _reader = [[TDMultipartDocumentReader alloc] initWithDatabase: database];
@@ -121,6 +125,7 @@ TestCase(TDMultipartDownloader) {
     [[[TDMultipartDownloader alloc] initWithURL: url
                                        database: db
                                      authorizer: nil
+                                 requestHeaders: nil
                                    onCompletion: ^(id result, NSError * error)
      {
          CAssertNil(error);

--- a/Source/TDMultipartUploader.h
+++ b/Source/TDMultipartUploader.h
@@ -19,6 +19,7 @@
 - (id) initWithURL: (NSURL *)url
           streamer: (TDMultipartWriter*)streamer
         authorizer: (id<TDAuthorizer>)authorizer
+    requestHeaders: (NSDictionary *) requestHeaders
       onCompletion: (TDRemoteRequestCompletionBlock)onCompletion;
 
 @end

--- a/Source/TDMultipartUploader.m
+++ b/Source/TDMultipartUploader.m
@@ -21,11 +21,15 @@
 - (id) initWithURL: (NSURL *)url
           streamer: (TDMultipartWriter*)streamer
         authorizer: (id<TDAuthorizer>)authorizer
+    requestHeaders: (NSDictionary *) requestHeaders
       onCompletion: (TDRemoteRequestCompletionBlock)onCompletion
 {
     Assert(streamer);
-    return [super initWithMethod: @"PUT" URL: url body: streamer
+    return [super initWithMethod: @"PUT" 
+                             URL: url 
+                            body: streamer
                       authorizer: authorizer
+                  requestHeaders:requestHeaders 
                     onCompletion: onCompletion];
 }
 

--- a/Source/TDPuller.m
+++ b/Source/TDPuller.m
@@ -315,6 +315,7 @@ static NSString* joinQuotedEscaped(NSArray* strings);
     [[[TDMultipartDownloader alloc] initWithURL: [NSURL URLWithString: urlStr]
                                        database: _db
                                      authorizer: _authorizer
+                                 requestHeaders: self.requestHeaders
                                    onCompletion:
         ^(TDMultipartDownloader* download, NSError *error) {
             // OK, now we've got the response revision:

--- a/Source/TDPusher.m
+++ b/Source/TDPusher.m
@@ -269,6 +269,7 @@ static int findCommonAncestor(TDRevision* rev, NSArray* possibleIDs);
     [[[TDMultipartUploader alloc] initWithURL: [NSURL URLWithString: urlStr]
                                      streamer: bodyStream
                                    authorizer: _authorizer
+                               requestHeaders: self.requestHeaders
                                  onCompletion: ^(id response, NSError *error) {
                   if (error) {
                       self.error = error;

--- a/Source/TDRemoteRequest.h
+++ b/Source/TDRemoteRequest.h
@@ -32,8 +32,11 @@ typedef void (^TDRemoteRequestCompletionBlock)(id result, NSError* error);
 }
 
 /** Creates and starts a request; when finished, the onCompletion block will be called. */
-- (id) initWithMethod: (NSString*)method URL: (NSURL*)url body: (id)body
+- (id) initWithMethod: (NSString*)method 
+                  URL: (NSURL*)url 
+                 body: (id)body
            authorizer: (id<TDAuthorizer>)authorizer
+       requestHeaders:(NSDictionary *) requestHeaders
          onCompletion: (TDRemoteRequestCompletionBlock)onCompletion;
 
 /** In some cases a kTDStatusNotFound Not Found is an expected condition and shouldn't be logged; call this to suppress that log message. */

--- a/Source/TDRemoteRequest.m
+++ b/Source/TDRemoteRequest.m
@@ -31,8 +31,11 @@
 @implementation TDRemoteRequest
 
 
-- (id) initWithMethod: (NSString*)method URL: (NSURL*)url body: (id)body
+- (id) initWithMethod: (NSString*)method 
+                  URL: (NSURL*)url 
+                 body: (id)body
            authorizer: (id<TDAuthorizer>)authorizer
+       requestHeaders:(NSDictionary *) requestHeaders
          onCompletion: (TDRemoteRequestCompletionBlock)onCompletion
 {
     self = [super init];
@@ -43,6 +46,11 @@
         _request.cachePolicy = NSURLRequestReloadIgnoringLocalCacheData;
         [_request setValue: $sprintf(@"TouchDB/%@", [TDRouter versionString])
                   forHTTPHeaderField:@"User-Agent"];
+        
+        // Add headers.
+        [requestHeaders enumerateKeysAndObjectsUsingBlock:^(id key, id value, BOOL *stop) {
+            [_request addValue:value forHTTPHeaderField:key];
+        }];
         
         LogTo(RemoteRequest, @"%@: Starting...", self);
         [self setupRequest: _request withBody: body];

--- a/Source/TDReplicator.h
+++ b/Source/TDReplicator.h
@@ -56,6 +56,10 @@ extern NSString* TDReplicatorStoppedNotification;
 @property (copy) NSString* filterName;
 @property (copy) NSDictionary* filterParameters;
 @property (copy) NSDictionary* options;
+
+/** Optional dictionary of headers to be added to all requests to remote servers. */
+@property (copy) NSDictionary* requestHeaders;
+
 @property (retain) id<TDAuthorizer> authorizer;
 
 /** Starts the replicator.

--- a/Source/TDReplicator.m
+++ b/Source/TDReplicator.m
@@ -87,6 +87,7 @@ NSString* TDReplicatorStoppedNotification = @"TDReplicatorStopped";
     [_error release];
     [_authorizer release];
     [_options release];
+    [_requestHeaders release];
     [super dealloc];
 }
 
@@ -109,6 +110,7 @@ NSString* TDReplicatorStoppedNotification = @"TDReplicatorStopped";
 @synthesize changesProcessed=_changesProcessed, changesTotal=_changesTotal;
 @synthesize remoteCheckpoint=_remoteCheckpoint;
 @synthesize authorizer=_authorizer;
+@synthesize requestHeaders = _requestHeaders;
 
 
 - (BOOL) isPush {
@@ -315,9 +317,9 @@ NSString* TDReplicatorStoppedNotification = @"TDReplicatorStopped";
                                                     URL: url
                                                    body: body
                                              authorizer: _authorizer
+                                         requestHeaders: self.requestHeaders 
                                            onCompletion: onCompletion] autorelease];
 }
-
 
 #pragma mark - CHECKPOINT STORAGE:
 

--- a/TouchDB.xcodeproj/xcshareddata/xcschemes/Mac Demo.xcscheme
+++ b/TouchDB.xcodeproj/xcshareddata/xcschemes/Mac Demo.xcscheme
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
+   LastUpgradeVersion = "0430"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -39,7 +40,7 @@
       </MacroExpansion>
    </TestAction>
    <LaunchAction
-      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.GDB"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.GDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"

--- a/TouchDB.xcodeproj/xcshareddata/xcschemes/Mac Framework.xcscheme
+++ b/TouchDB.xcodeproj/xcshareddata/xcschemes/Mac Framework.xcscheme
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
+   LastUpgradeVersion = "0430"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -40,11 +41,12 @@
       </Testables>
    </TestAction>
    <LaunchAction
-      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.GDB"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.GDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       buildConfiguration = "Debug"
+      ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       allowLocationSimulation = "YES">
       <AdditionalOptions>

--- a/TouchDB.xcodeproj/xcshareddata/xcschemes/iOS Demo.xcscheme
+++ b/TouchDB.xcodeproj/xcshareddata/xcschemes/iOS Demo.xcscheme
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
+   LastUpgradeVersion = "0430"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -39,7 +40,7 @@
       </MacroExpansion>
    </TestAction>
    <LaunchAction
-      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.GDB"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.GDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"

--- a/TouchDB.xcodeproj/xcshareddata/xcschemes/iOS Empty App.xcscheme
+++ b/TouchDB.xcodeproj/xcshareddata/xcschemes/iOS Empty App.xcscheme
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
+   LastUpgradeVersion = "0430"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -39,11 +40,12 @@
       </MacroExpansion>
    </TestAction>
    <LaunchAction
-      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.GDB"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.GDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       buildConfiguration = "Debug"
+      ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       allowLocationSimulation = "YES">
       <BuildableProductRunnable>

--- a/TouchDB.xcodeproj/xcshareddata/xcschemes/iOS Framework.xcscheme
+++ b/TouchDB.xcodeproj/xcshareddata/xcschemes/iOS Framework.xcscheme
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
+   LastUpgradeVersion = "0430"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -30,11 +31,12 @@
       </Testables>
    </TestAction>
    <LaunchAction
-      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.GDB"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.GDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       buildConfiguration = "Debug"
+      ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       allowLocationSimulation = "YES">
       <AdditionalOptions>

--- a/TouchDB.xcodeproj/xcshareddata/xcschemes/iOS TouchDBListener.xcscheme
+++ b/TouchDB.xcodeproj/xcshareddata/xcschemes/iOS TouchDBListener.xcscheme
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
+   LastUpgradeVersion = "0430"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -30,11 +31,12 @@
       </Testables>
    </TestAction>
    <LaunchAction
-      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.GDB"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.GDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       buildConfiguration = "Debug"
+      ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       allowLocationSimulation = "YES">
       <AdditionalOptions>


### PR DESCRIPTION
- Added options request headers to sync code.
- Added authorisation to socket change tracker.

The essence of this commit was to be able to specify additional headers such as User-Agent which are added to all server request during a sync. These headers are passed as a dictionary to the TReplicator which passes them on to the various replicator classes.
