### PR TITLE
TDReplicator notification strings as class messages

### DIFF
--- a/Source/TDReplicator.h
+++ b/Source/TDReplicator.h
@@ -45,6 +45,9 @@ extern NSString* TDReplicatorStoppedNotification;
     NSDictionary* _requestHeaders;
 }
 
++ (NSString *)progressChangedNotification;
++ (NSString *)stoppedNotification;
+
 - (id) initWithDB: (TDDatabase*)db
            remote: (NSURL*)remote
              push: (BOOL)push

--- a/Source/TDReplicator.m
+++ b/Source/TDReplicator.m
@@ -46,6 +46,17 @@ NSString* TDReplicatorStoppedNotification = @"TDReplicatorStopped";
 
 @implementation TDReplicator
 
++ (NSString *)progressChangedNotification
+{
+    return TDReplicatorProgressChangedNotification;
+}
+
++ (NSString *)stoppedNotification
+{
+    return TDReplicatorStoppedNotification;
+}
+
+
 - (id) initWithDB: (TDDatabase*)db
            remote: (NSURL*)remote
              push: (BOOL)push


### PR DESCRIPTION
In order to remove the last link-time dependency CouchCocoa has on TouchDB, I exposed the notification strings which the TDReplicator uses for notifications as static class messages.
