### PR TITLE
avoid overriding authorization header if no arthorizer is specified

### DIFF
--- a/Source/TDRemoteRequest.m
+++ b/Source/TDRemoteRequest.m
@@ -70,9 +70,11 @@
 }
 
 - (void) setAuthorizer: (id<TDAuthorizer>)authorizer {
-    setObj(&_authorizer, authorizer);
-    [_request setValue: [authorizer authorizeURLRequest: _request forRealm: nil]
-              forHTTPHeaderField: @"Authorization"];
+    if (authorizer) {
+        setObj(&_authorizer, authorizer);
+        [_request setValue: [authorizer authorizeURLRequest: _request forRealm: nil]
+        forHTTPHeaderField: @"Authorization"];
+    }
 }
 
 


### PR DESCRIPTION
If Authorization header is set via 'header' property and no authorizer is set, the header is override by setAuthorizer: .
