### PR TITLE
Clean up prefix header for CocoaPods compatibility

### DIFF
--- a/Source/ChangeTracker/TDChangeTracker.m
+++ b/Source/ChangeTracker/TDChangeTracker.m
@@ -20,6 +20,10 @@
 #import "TDAuthorizer.h"
 #import "TDMisc.h"
 #import "TDStatus.h"
+#import "TDJSON.h"
+
+#import "Test.h"
+
 
 
 #define kDefaultHeartbeat (5 * 60.0)

--- a/Source/ChangeTracker/TDConnectionChangeTracker.m
+++ b/Source/ChangeTracker/TDConnectionChangeTracker.m
@@ -21,7 +21,8 @@
 #import "TDMisc.h"
 #import "TDStatus.h"
 #import "MYURLUtils.h"
-
+#import "Logging.h"
+#import "CollectionUtils.h"
 
 static SecTrustRef CopyTrustWithPolicy(SecTrustRef trust, SecPolicyRef policy);
 

--- a/Source/TDAttachment.m
+++ b/Source/TDAttachment.m
@@ -7,7 +7,7 @@
 //
 
 #import "TDAttachment.h"
-
+#import "Test.h"
 
 @implementation TDAttachment
 

--- a/Source/TDAuthorizer.m
+++ b/Source/TDAuthorizer.m
@@ -10,7 +10,7 @@
 #import "TDMisc.h"
 #import "TDBase64.h"
 #import "MYURLUtils.h"
-
+#import "Test.h"
 
 @implementation TDBasicAuthorizer
 

--- a/Source/TDBlobStore.m
+++ b/Source/TDBlobStore.m
@@ -17,7 +17,7 @@
 #import "TDBase64.h"
 #import "TDMisc.h"
 #import <ctype.h>
-
+#import "Test.h"
 
 #ifdef GNUSTEP
 #define NSDataReadingMappedIfSafe NSMappedRead

--- a/Source/TDBody.m
+++ b/Source/TDBody.m
@@ -14,6 +14,10 @@
 //  and limitations under the License.
 
 #import "TDBody.h"
+#import "TDJSON.h"
+
+#import "Logging.h"
+#import "CollectionUtils.h"
 
 
 @implementation TDBody

--- a/Source/TDCanonicalJSON.m
+++ b/Source/TDCanonicalJSON.m
@@ -14,6 +14,7 @@
 //  and limitations under the License.
 
 #import "TDCanonicalJSON.h"
+#import "Test.h"
 #import <math.h>
 
 

--- a/Source/TDCollateJSON.m
+++ b/Source/TDCollateJSON.m
@@ -16,7 +16,8 @@
 //  http://wiki.apache.org/couchdb/View_collation#Collation_Specification
 
 #import "TDCollateJSON.h"
-
+#import "Logging.h"
+#import "Test.h"
 
 static int cmp(int n1, int n2) {
     int diff = n1 - n2;

--- a/Source/TDDatabase+Attachments.m
+++ b/Source/TDDatabase+Attachments.m
@@ -35,6 +35,8 @@
 #import "TDInternal.h"
 
 #import "CollectionUtils.h"
+#import "Test.h"
+
 #import "FMDatabase.h"
 #import "FMDatabaseAdditions.h"
 #import "FMResultSet.h"

--- a/Source/TDDatabase+LocalDocs.m
+++ b/Source/TDDatabase+LocalDocs.m
@@ -17,6 +17,9 @@
 #import <TouchDB/TDRevision.h>
 #import "TDBody.h"
 #import "TDInternal.h"
+#import "TDJSON.h"
+
+#import "CollectionUtils.h"
 
 #import "FMDatabase.h"
 

--- a/Source/TDDatabase+Replication.m
+++ b/Source/TDDatabase+Replication.m
@@ -16,7 +16,9 @@
 #import "TDDatabase+Replication.h"
 #import "TDInternal.h"
 #import "TDPuller.h"
+
 #import "MYBlockUtils.h"
+#import "CollectionUtils.h"
 
 #import "FMDatabase.h"
 #import "FMDatabaseAdditions.h"

--- a/Source/TDDatabase.m
+++ b/Source/TDDatabase.m
@@ -22,6 +22,11 @@
 #import "TDPuller.h"
 #import "TDPusher.h"
 #import "TDMisc.h"
+#import "TDJSON.h"
+
+#import "CollectionUtils.h"
+#import "Logging.h"
+#import "Test.h"
 
 #import "FMDatabase.h"
 #import "FMDatabaseAdditions.h"

--- a/Source/TDDatabaseManager.m
+++ b/Source/TDDatabaseManager.m
@@ -19,6 +19,8 @@
 #import "TDInternal.h"
 #import "TDMisc.h"
 
+#import "Logging.h"
+#import "CollectionUtils.h"
 
 @implementation TDDatabaseManager
 

--- a/Source/TDJSON.m
+++ b/Source/TDJSON.m
@@ -19,6 +19,8 @@
 #import "JSONKit.h"
 #endif
 
+#import "CollectionUtils.h"
+#import "Test.h"
 
 @implementation TDJSON
 

--- a/Source/TDMisc.m
+++ b/Source/TDMisc.m
@@ -16,7 +16,7 @@
 #import "TDMisc.h"
 
 #import "CollectionUtils.h"
-
+#import "Test.h"
 
 #ifdef GNUSTEP
 #import <openssl/sha.h>

--- a/Source/TDMultipartDocumentReader.m
+++ b/Source/TDMultipartDocumentReader.m
@@ -19,8 +19,11 @@
 #import "TDInternal.h"
 #import "TDBase64.h"
 #import "TDMisc.h"
-#import "CollectionUtils.h"
+#import "TDJSON.h"
+
 #import "MYStreamUtils.h"
+#import "CollectionUtils.h"
+#import "Test.h"
 
 
 @implementation TDMultipartDocumentReader

--- a/Source/TDMultipartDownloader.m
+++ b/Source/TDMultipartDownloader.m
@@ -18,7 +18,9 @@
 #import "TDBlobStore.h"
 #import "TDInternal.h"
 #import "TDMisc.h"
+
 #import "CollectionUtils.h"
+#import "Logging.h"
 
 
 @implementation TDMultipartDownloader

--- a/Source/TDMultipartUploader.m
+++ b/Source/TDMultipartUploader.m
@@ -15,6 +15,9 @@
 
 #import "TDMultipartUploader.h"
 
+#import "Logging.h"
+#import "Test.h"
+
 
 @implementation TDMultipartUploader
 

--- a/Source/TDOAuth1Authorizer.m
+++ b/Source/TDOAuth1Authorizer.m
@@ -9,11 +9,13 @@
 #import "TDOAuth1Authorizer.h"
 #import "TDMisc.h"
 #import "TDBase64.h"
+
 #import "OAMutableURLRequest.h"
 #import "OAConsumer.h"
 #import "OAToken.h"
 #import "OAPlaintextSignatureProvider.h"
 
+#import "Test.h"
 
 @implementation TDOAuth1Authorizer
 

--- a/Source/TDPuller.m
+++ b/Source/TDPuller.m
@@ -24,8 +24,11 @@
 #import "TDSequenceMap.h"
 #import "TDInternal.h"
 #import "TDMisc.h"
-#import "ExceptionUtils.h"
+#import "TDJSON.h"
 
+#import "ExceptionUtils.h"
+#import "Logging.h"
+#import "Test.h"
 
 // Maximum number of revisions to fetch simultaneously
 #define kMaxOpenHTTPConnections 8

--- a/Source/TDPusher.m
+++ b/Source/TDPusher.m
@@ -21,6 +21,9 @@
 #import "TDInternal.h"
 #import "TDMisc.h"
 
+#import "Logging.h"
+#import "CollectionUtils.h"
+#import "Test.h"
 
 static int findCommonAncestor(TDRevision* rev, NSArray* possibleIDs);
 

--- a/Source/TDReachability.m
+++ b/Source/TDReachability.m
@@ -17,6 +17,8 @@
 #import <SystemConfiguration/SystemConfiguration.h>
 #include <arpa/inet.h>
 
+#import "CollectionUtils.h"
+
 
 static void ClientCallback(SCNetworkReachabilityRef target,
                            SCNetworkReachabilityFlags flags,

--- a/Source/TDRemoteRequest.m
+++ b/Source/TDRemoteRequest.m
@@ -20,10 +20,14 @@
 #import <TouchDB/TDDatabase.h>
 #import "TDRouter.h"
 #import "TDReplicator.h"
+#import "TDJSON.h"
+
+#import "MYURLUtils.h"
 #import "CollectionUtils.h"
 #import "Logging.h"
 #import "Test.h"
-#import "MYURLUtils.h"
+
+
 
 
 // Max number of retry attempts for a transient failure, and the backoff time formula

--- a/Source/TDReplicator.m
+++ b/Source/TDReplicator.m
@@ -25,8 +25,11 @@
 #import "TDMisc.h"
 #import "TDBase64.h"
 #import "TDCanonicalJSON.h"
+
 #import "MYBlockUtils.h"
 #import "MYURLUtils.h"
+#import "Test.h"
+#import "CollectionUtils.h"
 
 #if TARGET_OS_IPHONE
 #import <UIKit/UIApplication.h>

--- a/Source/TDReplicatorManager.m
+++ b/Source/TDReplicatorManager.m
@@ -27,7 +27,11 @@
 #import "TDOAuth1Authorizer.h"
 #import "TDInternal.h"
 #import "TDMisc.h"
+
 #import "MYBlockUtils.h"
+#import "Logging.h"
+#import "CollectionUtils.h"
+#import "Test.h"
 
 #if TARGET_OS_IPHONE
 #import <UIKit/UIApplication.h>

--- a/Source/TDRevision.m
+++ b/Source/TDRevision.m
@@ -17,6 +17,9 @@
 #import "TDBody.h"
 #import "TDMisc.h"
 
+#import "CollectionUtils.h"
+#import "Logging.h"
+#import "Test.h"
 
 @implementation TDRevision
 

--- a/Source/TDRouter+Handlers.m
+++ b/Source/TDRouter+Handlers.m
@@ -29,7 +29,10 @@
 #import "TDPusher.h"
 #import "TDInternal.h"
 #import "TDMisc.h"
+#import "TDJSON.h"
 
+#import "CollectionUtils.h"
+#import "Test.h"
 
 @implementation TDRouter (Handlers)
 

--- a/Source/TDRouter.m
+++ b/Source/TDRouter.m
@@ -21,8 +21,13 @@
 #import "TDMultipartWriter.h"
 #import "TDReplicatorManager.h"
 #import "TDInternal.h"
+#import "TDJSON.h"
+
 #import "ExceptionUtils.h"
 #import "MYRegexUtils.h"
+#import "CollectionUtils.h"
+#import "Logging.h"
+#import "Test.h"
 
 #ifdef GNUSTEP
 #import <GNUstepBase/NSURL+GNUstepBase.h>

--- a/Source/TDSequenceMap.m
+++ b/Source/TDSequenceMap.m
@@ -14,7 +14,7 @@
 //  and limitations under the License.
 
 #import "TDSequenceMap.h"
-
+#import "Test.h"
 
 @implementation TDSequenceMap
 

--- a/Source/TDServer.m
+++ b/Source/TDServer.m
@@ -20,7 +20,10 @@
 #import "TDDatabaseManager.h"
 #import "TDInternal.h"
 #import "TDURLProtocol.h"
+
 #import "MYBlockUtils.h"
+#import "Logging.h"
+#import "Test.h"
 
 
 @implementation TDServer

--- a/Source/TDStatus.m
+++ b/Source/TDStatus.m
@@ -14,7 +14,7 @@
 //  and limitations under the License.
 
 #import "TDStatus.h"
-
+#import "CollectionUtils.h"
 
 NSString* const TDHTTPErrorDomain = @"TDHTTP";
 

--- a/Source/TDURLProtocol.m
+++ b/Source/TDURLProtocol.m
@@ -17,8 +17,10 @@
 #import "TDRouter.h"
 #import "TDServer.h"
 #import "TDInternal.h"
-#import "MYBlockUtils.h"
 
+#import "MYBlockUtils.h"
+#import "Logging.h"
+#import "CollectionUtils.h"
 
 #define kScheme @"touchdb"
 

--- a/Source/TDView.m
+++ b/Source/TDView.m
@@ -15,6 +15,10 @@
 
 #import "TDView.h"
 #import "TDInternal.h"
+#import "TDJSON.h"
+
+#import "CollectionUtils.h"
+#import "Test.h"
 
 #import "FMDatabase.h"
 #import "FMDatabaseAdditions.h"

--- a/Source/TouchDBPrefix.h
+++ b/Source/TouchDBPrefix.h
@@ -14,10 +14,4 @@
 
 #import <Foundation/Foundation.h>
 
-#import "TDJSON.h"
-
-#import "CollectionUtils.h"
-#import "Logging.h"
-#import "Test.h"
-
 #endif


### PR DESCRIPTION
I've been working on getting CouchCocoa and TouchDB working with CocoaPods. TouchDB in particular has some problems I had to work around. This fixes one of them; I'll file issues for the others. 
