### PR TITLE
Fixes #188; Fix by not instantiating _pendingSequences if it was previou...

### DIFF
--- a/Source/TDPuller.m
+++ b/Source/TDPuller.m
@@ -74,9 +74,10 @@ static NSString* joinQuotedEscaped(NSArray* strings);
                                                       [self insertDownloads: downloads];
                                                   }];
     }
-
-    [_pendingSequences release];
-    _pendingSequences = [[TDSequenceMap alloc] init];
+    
+    if (!_pendingSequences) {
+        _pendingSequences = [[TDSequenceMap alloc] init];
+    }
 
     _caughtUp = NO;
     [self asyncTaskStarted];   // task: waiting to catch up


### PR DESCRIPTION
...sly instantiating.  Otherwise, _batcher and _pendingSequences get out of sync and an assertion fails later and causes a crash.  Needs review - can this change have any unwanted side effects?
