### PR TITLE
normalized import directives to use quotes (public-api branch)

### DIFF
--- a/Listener/TouchServ.m
+++ b/Listener/TouchServ.m
@@ -14,14 +14,14 @@
 //  and limitations under the License.
 
 #import <Foundation/Foundation.h>
-#import <TouchDB/TouchDB.h>
-#import <TouchDB/TD_Server.h>
-#import <TouchDB/TDURLProtocol.h>
-#import <TouchDB/TDRouter.h>
-#import <TouchDBListener/TDListener.h>
-#import <TouchDB/TDPusher.h>
-#import <TouchDB/TD_DatabaseManager.h>
-#import <TouchDB/TD_Database+Replication.h>
+#import "TouchDB.h"
+#import "TD_Server.h"
+#import "TDURLProtocol.h"
+#import "TDRouter.h"
+#import "TDListener.h"
+#import "TDPusher.h"
+#import "TD_DatabaseManager.h"
+#import "TD_Database+Replication.h"
 #import "TDMisc.h"
 
 #if DEBUG

--- a/Source/TDInternal.h
+++ b/Source/TDInternal.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2011 Couchbase, Inc. All rights reserved.
 //
 
-#import <TouchDB/TD_Database.h>
+#import "TD_Database.h"
 #import "TD_Database+Attachments.h"
 #import "TD_DatabaseManager.h"
 #import "TD_View.h"

--- a/Source/TDMisc.h
+++ b/Source/TDMisc.h
@@ -7,7 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
-#import <TouchDB/TD_Revision.h>
+#import "TD_Revision.h"
 
 NSString* TDVersionString( void );
 

--- a/Source/TDMultipartDocumentReader.h
+++ b/Source/TDMultipartDocumentReader.h
@@ -7,7 +7,7 @@
 //
 
 #import "TDMultipartReader.h"
-#import <TouchDB/TDStatus.h>
+#import "TDStatus.h"
 @class TD_Database, TD_Revision, TDBlobStoreWriter, TDMultipartDocumentReader;
 
 

--- a/Source/TDPuller.h
+++ b/Source/TDPuller.h
@@ -7,7 +7,7 @@
 //
 
 #import "TDReplicator.h"
-#import <TouchDB/TD_Revision.h>
+#import "TD_Revision.h"
 @class TDChangeTracker, TDSequenceMap;
 
 

--- a/Source/TDPuller.m
+++ b/Source/TDPuller.m
@@ -16,7 +16,7 @@
 #import "TDPuller.h"
 #import "TD_Database+Insertion.h"
 #import "TD_Database+Replication.h"
-#import <TouchDB/TD_Revision.h>
+#import "TD_Revision.h"
 #import "TDChangeTracker.h"
 #import "TDAuthorizer.h"
 #import "TDBatcher.h"

--- a/Source/TDPusher.h
+++ b/Source/TDPusher.h
@@ -7,7 +7,7 @@
 //
 
 #import "TDPuller.h"
-#import <TouchDB/TD_Database.h>
+#import "TD_Database.h"
 
 
 /** Replicator that pushes to a remote CouchDB. */

--- a/Source/TDPusher.m
+++ b/Source/TDPusher.m
@@ -14,9 +14,9 @@
 //  and limitations under the License.
 
 #import "TDPusher.h"
-#import <TouchDB/TD_Database.h>
+#import "TD_Database.h"
 #import "TD_Database+Insertion.h"
-#import <TouchDB/TD_Revision.h>
+#import "TD_Revision.h"
 #import "TDBatcher.h"
 #import "TDMultipartUploader.h"
 #import "TDInternal.h"

--- a/Source/TDRemoteRequest.m
+++ b/Source/TDRemoteRequest.m
@@ -17,7 +17,7 @@
 #import "TDAuthorizer.h"
 #import "TDMisc.h"
 #import "TDBlobStore.h"
-#import <TouchDB/TD_Database.h>
+#import "TD_Database.h"
 #import "TDRouter.h"
 #import "TDReplicator.h"
 #import "CollectionUtils.h"

--- a/Source/TDReplicator.m
+++ b/Source/TDReplicator.m
@@ -16,7 +16,7 @@
 #import "TDReplicator.h"
 #import "TDPusher.h"
 #import "TDPuller.h"
-#import <TouchDB/TD_Database.h>
+#import "TD_Database.h"
 #import "TDRemoteRequest.h"
 #import "TDAuthorizer.h"
 #import "TDBatcher.h"

--- a/Source/TDReplicatorManager.h
+++ b/Source/TDReplicatorManager.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2012 Couchbase, Inc. All rights reserved.
 //
 
-#import <TouchDB/TD_Database.h>
+#import "TD_Database.h"
 @class TD_DatabaseManager;
 @protocol TDAuthorizer;
 

--- a/Source/TDReplicatorManager.m
+++ b/Source/TDReplicatorManager.m
@@ -18,7 +18,7 @@
 
 #import "TDReplicatorManager.h"
 #import "TD_Server.h"
-#import <TouchDB/TD_Database.h>
+#import "TD_Database.h"
 #import "TD_Database+Insertion.h"
 #import "TD_Database+Replication.h"
 #import "TDPusher.h"

--- a/Source/TDRouter+Handlers.m
+++ b/Source/TDRouter+Handlers.m
@@ -14,7 +14,7 @@
 //  and limitations under the License.
 
 #import "TDRouter.h"
-#import <TouchDB/TD_Database.h>
+#import "TD_Database.h"
 #import "TD_Database+Attachments.h"
 #import "TD_Database+Insertion.h"
 #import "TD_Database+LocalDocs.h"
@@ -22,7 +22,7 @@
 #import "TD_View.h"
 #import "TD_Body.h"
 #import "TDMultipartDocumentReader.h"
-#import <TouchDB/TD_Revision.h>
+#import "TD_Revision.h"
 #import "TD_Server.h"
 #import "TDReplicator.h"
 #import "TDReplicatorManager.h"

--- a/Source/TDRouter.h
+++ b/Source/TDRouter.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2011 Couchbase, Inc. All rights reserved.
 //
 
-#import <TouchDB/TD_Database.h>
+#import "TD_Database.h"
 @class TD_Server, TD_DatabaseManager, TDResponse, TD_Body, TDMultipartWriter;
 
 

--- a/Source/TDRouter_Tests.m
+++ b/Source/TDRouter_Tests.m
@@ -14,7 +14,7 @@
 //  and limitations under the License.
 
 #import "TDRouter.h"
-#import <TouchDB/TD_Database.h>
+#import "TD_Database.h"
 #import "TD_Body.h"
 #import "TD_Server.h"
 #import "TDBase64.h"

--- a/Source/TDSequenceMap.h
+++ b/Source/TDSequenceMap.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2012 Couchbase, Inc. All rights reserved.
 //
 
-#import <TouchDB/TD_Revision.h>
+#import "TD_Revision.h"
 
 
 /** A data structure representing a type of array that allows object values to be added to the end, and removed in arbitrary order; it's used by the replicator to keep track of which revisions have been transferred and what sequences to checkpoint. */

--- a/Source/TD_Database+Attachments.h
+++ b/Source/TD_Database+Attachments.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2012 Couchbase, Inc. All rights reserved.
 //
 
-#import <TouchDB/TD_Database.h>
+#import "TD_Database.h"
 @class TDBlobStoreWriter, TDMultipartWriter;
 
 

--- a/Source/TD_Database+Insertion.h
+++ b/Source/TD_Database+Insertion.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2012 Couchbase, Inc. All rights reserved.
 //
 
-#import <TouchDB/TD_Database.h>
+#import "TD_Database.h"
 #import "TDDatabase.h"
 @protocol TD_ValidationContext;
 

--- a/Source/TD_Database+Insertion.m
+++ b/Source/TD_Database+Insertion.m
@@ -18,7 +18,7 @@
 #import "TDDatabase.h"
 #import "TouchDBPrivate.h"
 #import "TDDocument.h"
-#import <TouchDB/TD_Revision.h>
+#import "TD_Revision.h"
 #import "TDCanonicalJSON.h"
 #import "TD_Attachment.h"
 #import "TDInternal.h"

--- a/Source/TD_Database+LocalDocs.h
+++ b/Source/TD_Database+LocalDocs.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2012 Couchbase, Inc. All rights reserved.
 //
 
-#import <TouchDB/TD_Database.h>
+#import "TD_Database.h"
 
 
 @interface TD_Database (LocalDocs)

--- a/Source/TD_Database+LocalDocs.m
+++ b/Source/TD_Database+LocalDocs.m
@@ -14,7 +14,7 @@
 //  and limitations under the License.
 
 #import "TD_Database+LocalDocs.h"
-#import <TouchDB/TD_Revision.h>
+#import "TD_Revision.h"
 #import "TD_Body.h"
 #import "TDInternal.h"
 

--- a/Source/TD_Database+Replication.h
+++ b/Source/TD_Database+Replication.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2012 Couchbase, Inc. All rights reserved.
 //
 
-#import <TouchDB/TD_Database.h>
+#import "TD_Database.h"
 @class TDReplicator;
 
 

--- a/Source/TD_Database.h
+++ b/Source/TD_Database.h
@@ -7,8 +7,8 @@
  *
  */
 
-#import <TouchDB/TD_Revision.h>
-#import <TouchDB/TDStatus.h>
+#import "TD_Revision.h"
+#import "TDStatus.h"
 @class FMDatabase, TD_View, TDBlobStore, TDDocument, TDCache, TDDatabase;
 struct TDQueryOptions;      // declared in TD_View.h
 

--- a/Source/TD_Database.m
+++ b/Source/TD_Database.m
@@ -13,10 +13,10 @@
 //  either express or implied. See the License for the specific language governing permissions
 //  and limitations under the License.
 
-#import <TouchDB/TD_Database.h>
+#import "TD_Database.h"
 #import "TD_Database+Attachments.h"
 #import "TDInternal.h"
-#import <TouchDB/TD_Revision.h>
+#import "TD_Revision.h"
 #import "TDCollateJSON.h"
 #import "TDBlobStore.h"
 #import "TDPuller.h"

--- a/Source/TD_DatabaseManager.m
+++ b/Source/TD_DatabaseManager.m
@@ -14,7 +14,7 @@
 //  and limitations under the License.
 
 #import "TD_DatabaseManager.h"
-#import <TouchDB/TD_Database.h>
+#import "TD_Database.h"
 #import "TDReplicatorManager.h"
 #import "TDInternal.h"
 #import "TDMisc.h"

--- a/Source/TD_Database_Tests.m
+++ b/Source/TD_Database_Tests.m
@@ -14,14 +14,14 @@
 //  and limitations under the License.
 
 
-#import <TouchDB/TD_Database.h>
+#import "TD_Database.h"
 #import "TD_Database+Attachments.h"
 #import "TD_Database+Insertion.h"
 #import "TD_Database+LocalDocs.h"
 #import "TD_Database+Replication.h"
 #import "TD_Attachment.h"
 #import "TD_Body.h"
-#import <TouchDB/TD_Revision.h>
+#import "TD_Revision.h"
 #import "TDBlobStore.h"
 #import "TDBase64.h"
 #import "TDInternal.h"

--- a/Source/TD_Revision.m
+++ b/Source/TD_Revision.m
@@ -13,7 +13,7 @@
 //  either express or implied. See the License for the specific language governing permissions
 //  and limitations under the License.
 
-#import <TouchDB/TD_Revision.h>
+#import "TD_Revision.h"
 #import "TD_Body.h"
 #import "TDMisc.h"
 

--- a/Source/TD_Server.m
+++ b/Source/TD_Server.m
@@ -14,7 +14,7 @@
 //  and limitations under the License.
 
 #import "TD_Server.h"
-#import <TouchDB/TD_Database.h>
+#import "TD_Database.h"
 #import "TDReplicatorManager.h"
 #import "TDMisc.h"
 #import "TD_DatabaseManager.h"

--- a/Source/TD_View.h
+++ b/Source/TD_View.h
@@ -7,7 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
-#import <TouchDB/TD_Database.h>
+#import "TD_Database.h"
 #import "TDView.h"
 
 


### PR DESCRIPTION
Hi Jens -

I found that the mixture of angle bracket and quoted #import declarations was causing trouble when I include TouchDB-iOS as a subproject, so I changed them all to quotes; e.g.

```
#import <TouchDB/TDDatabase.h>
```

becomes

```
#import "TDDatabase.h"
```

I didn't see a pattern to the usage of angle brackets versus quotes, so it seemed like changing them all to one style would be ok.  Let me know if you have any questions or objections.
