### PR TITLE
bug fix: issue 203

### DIFF
--- a/Source/API/APITests.m
+++ b/Source/API/APITests.m
@@ -248,6 +248,21 @@ TestCase(API_DeleteDocument) {
     CAssert(doc.isDeleted);
 }
 
+TestCase(API_PurgeDocument) {
+    TDDatabase* db = createEmptyDB();
+    NSDictionary* properties = @{@"testName": @"testPurgeDocument"};
+    TDDocument* doc = createDocumentWithProperties(db, properties);
+    CAssert(doc);
+    
+    NSString * docid = [doc.documentID copy];
+    
+    NSError* error;
+    CAssert([doc purgeDocument: &error]);
+
+    TDDocument* redoc = [db cachedDocumentWithID:docid];
+    CAssert(!redoc);
+}
+
 
 TestCase(API_AllDocuments) {
     TDDatabase* db = createEmptyDB();

--- a/Source/API/TDDocument.m
+++ b/Source/API/TDDocument.m
@@ -80,12 +80,15 @@ NSString* const kTDDocumentChangeNotification = @"TouchDocumentChange";
 
 
 - (BOOL) purgeDocument: (NSError**)outError {
-    TDStatus status = [_database.tddb purgeRevisions: @{self.documentID : @"*"} result: nil];
+    TDStatus status = [_database.tddb purgeRevisions: @{self.documentID : [NSArray arrayWithObject:@"*"]} result: nil];
     if (TDStatusIsError(status)) {
         if (outError) {
             *outError = TDStatusToNSError(status, nil);
             return NO;
         }
+    }
+    else {
+        [self.database clearDocumentCache];
     }
     return YES;
 }


### PR DESCRIPTION
Here's the fix for this issue.  The only part you might want to look at is the call to `[self.database clearDocumentCache]` in `purgeDocument:`.  I feel like the purged document should be removed from the cache so it isn't returned again if `cachedDocumentWithID:` is called.  Clearing the whole document cache is a bit drastic, but removing a single document from the cache would require a new method on TDDatabase.

Note that calling purgeDocument followed by documentWithID will result in a new, empty document with the same ID as the purged document.  This is a bit confusing ("hey, I just purged document F45E1789-5754-41AC-8FF6-444207B919DB -- why is it coming back?") but this behavior is as designed for documentWithID, which will return a new doc if the provided doc ID doesn't exist.  This is also the reason the unit test uses cachedDocumentWithID: when attempting to re-select the purged doc.
