### PR TITLE
[public-api] bug fix: setting an attachment's body to null should delete the attachment

### DIFF
--- a/Source/API/TDAttachment.h
+++ b/Source/API/TDAttachment.h
@@ -7,7 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
-@class TDDocument, TDRevisionBase;
+@class TDDocument, TDRevisionBase, TDRevision;
 
 
 /** A binary attachment to a document revision.
@@ -49,7 +49,7 @@
 
 /** Updates the body, creating a new document revision in the process.
     If all you need to do to a document is update a single attachment this is an easy way to do it; but if you need to change multiple attachments, or change other body properties, do them in one step by calling -putProperties:error: on the revision or document. */
-- (TDAttachment*) updateBody: (NSData*)body
+- (TDRevision*) updateBody: (NSData*)body
                  contentType: (NSString*)contentType
                        error: (NSError**)outError;
 

--- a/Source/API/TDAttachment.m
+++ b/Source/API/TDAttachment.m
@@ -135,7 +135,7 @@ static TDBlobStoreWriter* blobStoreWriterForBody(TD_Database* tddb, NSData* body
                         error: (NSError**)outError
 {
     Assert(_rev);
-    TDBlobStoreWriter* writer = blobStoreWriterForBody(_rev.database.tddb, body);
+    TDBlobStoreWriter* writer = body ? blobStoreWriterForBody(_rev.database.tddb, body) : nil;
     TDStatus status;
     TD_Revision* newRev = [_rev.database.tddb updateAttachment: _name
                                                           body: writer


### PR DESCRIPTION
I updated the API_Attachments unit test in APITests.m so it works with the public-api branch.  While doing this, I discovered that setting an attachment body to null in updateBody:contentType:error: does not actually delete the attachment.  The problem was that TDAttachment.m was passing in a non-null TDBlobStoreWriter as the body parameter of TD_Database updateAttachment:body:type:..., which was expecting a null body to indicate that the attachment should be removed.  This pull requests contains the updated test and a fix in TDAttachment.m for the issue.
