### PR TITLE
Hi, I've fixed a few crashes while trying to compile  iOS-Couchbase-Demo

### DIFF
--- a/Source/TDReplicator.m
+++ b/Source/TDReplicator.m
@@ -83,7 +83,7 @@ NSString* TDReplicatorStoppedNotification = @"TDReplicatorStopped";
     if (self) {
         _thread = [NSThread currentThread];
         _db = db;
-        _remote = remote;
+        _remote = [remote copy];
         _continuous = continuous;
         Assert(push == self.isPush);
 

--- a/Source/TDRouter.m
+++ b/Source/TDRouter.m
@@ -30,11 +30,12 @@
 #import <objc/message.h>
 #endif
 
-
+#ifndef COCOAPODS_BUILD
 #ifdef GNUSTEP
 static double TouchDBVersionNumber = 0.7;
 #else
 extern double TouchDBVersionNumber; // Defined in Xcode-generated TouchDB_vers.c
+#endif
 #endif
 
 

--- a/Source/TDRouter.m
+++ b/Source/TDRouter.m
@@ -557,9 +557,9 @@ static NSArray* splitPath( NSURL* url ) {
         LogTo(TDRouter, @"%@", output);
     }
     OnFinishedBlock onFinished = _onFinished;
-    [self stopNow];
     if (onFinished)
         onFinished();
+    [self stopNow];
 }
 
 

--- a/Source/TD_DatabaseManager.m
+++ b/Source/TD_DatabaseManager.m
@@ -37,8 +37,10 @@ static NSCharacterSet* kIllegalNameChars;
 
 + (void) initialize {
     if (self == [TD_DatabaseManager class]) {
-        kIllegalNameChars = [[NSCharacterSet characterSetWithCharactersInString: kLegalChars]
-                                        invertedSet];
+		// using -[NSObject copy] here because of crash, other people also do this, see
+		// http://stackoverflow.com/questions/10733698/static-objects-initialized-within-class-methods-in-arc
+        kIllegalNameChars = [[[NSCharacterSet characterSetWithCharactersInString: kLegalChars]
+                                        invertedSet] copy];
     }
 }
 


### PR DESCRIPTION
I've changed order of a few lines in `-[TDRouter finished]` because `onFinished` was already released by ARC in `-[TDRouter stopNow]`. Fixes a crash which prevented demo from even starting.

`TDReplicator`'s property `remote` should be copied because it's value could be instantiated in another thread and released there. Also caused crashes.

`+[TD_DatabaseManager initialize]` also fixed, see comments there (also was stably crashing for me without this fix).

I've also updated CocoaPods spec for TouchDB and that needed bumping version to 1.03. Sorry for that, but I saw no way of testing demo's podfile without this.

Btw, another pull request is coming for iOS-Couchbase-Demo itself.
