### PR TITLE
Fixed bug where view arguments that had spaces where not having '+' symb...

### DIFF
--- a/Source/TDRouter.m
+++ b/Source/TDRouter.m
@@ -115,7 +115,7 @@ extern double TouchDBVersionNumber; // Defined in Xcode-generated TouchDB_vers.c
 
 
 - (NSString*) query: (NSString*)param {
-    return [(self.queries)[param]
+    return [[(self.queries)[param] stringByReplacingOccurrencesOfString:@"+" withString:@" "]
                     stringByReplacingPercentEscapesUsingEncoding: NSUTF8StringEncoding];
 }
 


### PR DESCRIPTION
This patch fixes a bug with the TDRouter where URL arguments are not checked for '+' encoding of space characters. For example, with the request:

```
http://localhost.touchdb.//yellowlive-production/_design/ratesViews/_view/headings?q=&limit=10&timestamp=1366603145303&startkey=%22Transport+s%22&endkey=%22Transport+sz%22
```

Both the startkey and endkey have spaces in their values. But because the TDRouter does not check for these, it passes them through like this:

```
13:59:05.309| View: Query ratesViews/headings: SELECT key, value, docid FROM maps, revs, docs WHERE maps.view_id=? AND key >= ? AND key <= ? AND revs.sequence = maps.sequence AND docs.doc_id = revs.doc_id ORDER BY key LIMIT ?
Arguments: (
3,
"\"Transport+s\"",
"\"Transport+sz\"",
10
```

)

This patch tells the TDRouter to also replace any occurrences of the '+' symbol are replaced with spaces before de-encoding the rest of the value.
